### PR TITLE
Fix WITH Regex for New Lines

### DIFF
--- a/lib/active_record_proxy_adapters/primary_replica_proxy.rb
+++ b/lib/active_record_proxy_adapters/primary_replica_proxy.rb
@@ -16,7 +16,7 @@ module ActiveRecordProxyAdapters
       /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i
     ].map(&:freeze).freeze
     # All queries that match these patterns should be sent to the replica database
-    SQL_REPLICA_MATCHERS     = [/\A\s*(select|with[\s\S]*\)\s*select)\s/i].map(&:freeze).freeze
+    SQL_REPLICA_MATCHERS     = [/\A\s*(select|with\s[\s\S]*\)\s*select)\s/i].map(&:freeze).freeze
     # All queries that match these patterns should be sent to all databases
     SQL_ALL_MATCHERS         = [/\A\s*set\s/i].map(&:freeze).freeze
     # Local sets queries should not be sent to all datbases

--- a/lib/active_record_proxy_adapters/primary_replica_proxy.rb
+++ b/lib/active_record_proxy_adapters/primary_replica_proxy.rb
@@ -16,7 +16,7 @@ module ActiveRecordProxyAdapters
       /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i
     ].map(&:freeze).freeze
     # All queries that match these patterns should be sent to the replica database
-    SQL_REPLICA_MATCHERS     = [/\A\s*(select|with.+\)\s*select)\s/i].map(&:freeze).freeze
+    SQL_REPLICA_MATCHERS     = [/\A\s*(select|with[\s\S]*\)\s*select)\s/i].map(&:freeze).freeze
     # All queries that match these patterns should be sent to all databases
     SQL_ALL_MATCHERS         = [/\A\s*set\s/i].map(&:freeze).freeze
     # Local sets queries should not be sent to all datbases


### PR DESCRIPTION
There is an issue with makara where the 'with' regex does not account for newlines. 
This fixes it. `.` regex does all characters except for newlines.