### PR TITLE
Fix replica pool getter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.RUN_UNIQUE_ID }}_artifact_${{ matrix.ruby }}_${{ matrix.rails }}
+          name: coverage_ruby_${{ matrix.ruby }}_rails_${{ matrix.rails }}
           path: coverage/
           include-hidden-files: true
           if-no-files-found: error
@@ -179,6 +179,14 @@ jobs:
 
       - name: Collate Partial Coverage Resultsets
         run: bundle exec rake coverage:report
+
+      - name: Upload Full Coverage Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/
+          include-hidden-files: true
+          if-no-files-found: error
 
       - uses: joshmfrankel/simplecov-check-action@main
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## [Unreleased]
 
+- Fix replica connection pool getter when database configurations have multiple replicas
+
 ## [0.1.2] - 2024-12-16
 
-Fix CTE regex matcher (4b1d10b)
+- Fix CTE regex matcher (4b1d10b)
 
 ## [0.1.1] - 2024-11-27
 

--- a/lib/active_record_proxy_adapters/primary_replica_proxy.rb
+++ b/lib/active_record_proxy_adapters/primary_replica_proxy.rb
@@ -65,12 +65,12 @@ module ActiveRecordProxyAdapters
     delegate :connected_to_stack, to: :connection_class
     delegate :reading_role, :writing_role, to: :active_record_context
 
-    def connection_class
-      active_record_context.connection_class_for(primary_connection)
+    def replica_pool
+      connection_class.connected_to(role: reading_role) { connection_class.connection_pool }
     end
 
-    def replica_pool
-      ActiveRecord::Base.connected_to(role: reading_role) { ActiveRecord::Base.connection_pool }
+    def connection_class
+      active_record_context.connection_class_for(primary_connection)
     end
 
     def coerce_query_to_string(sql_or_arel)


### PR DESCRIPTION
Use the connection class instead of `ActiveRecord::Base` to find the correct replica pool, in case of multiple models that connect to separate replicas. 