### PR TITLE
Fix raise ArgumentError, "Unknown type #{symbol.inspect}" error

### DIFF
--- a/lib/active_record/connection_adapters/mysql2_proxy_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2_proxy_adapter.rb
@@ -26,7 +26,18 @@ module ActiveRecord
       private
 
       attr_reader :proxy
+      ActiveRecord::Type.register(:immutable_string, adapter: :mysql2_proxy) do |_, **args|
+        Type::ImmutableString.new(true: "1", false: "0", **args)
+      end
+
+      ActiveRecord::Type.register(:string, adapter: :mysql2_proxy) do |_, **args|
+        Type::String.new(true: "1", false: "0", **args)
+      end
+
+      ActiveRecord::Type.register(:unsigned_integer, Type::UnsignedInteger, adapter: :mysql2_proxy)
     end
+
+    ActiveSupport.run_load_hooks(:active_record_mysql2proxyadapter, Mysql2ProxyAdapter)
   end
 end
 

--- a/lib/active_record/connection_adapters/postgresql_proxy_adapter.rb
+++ b/lib/active_record/connection_adapters/postgresql_proxy_adapter.rb
@@ -30,7 +30,28 @@ module ActiveRecord
       private
 
       attr_reader :proxy
+      ActiveRecord::Type.add_modifier({ array: true }, OID::Array, adapter: :postgresql_proxy)
+      ActiveRecord::Type.add_modifier({ range: true }, OID::Range, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:bit, OID::Bit, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:bit_varying, OID::BitVarying, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:binary, OID::Bytea, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:cidr, OID::Cidr, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:date, OID::Date, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:datetime, OID::DateTime, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:decimal, OID::Decimal, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:enum, OID::Enum, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:hstore, OID::Hstore, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:inet, OID::Inet, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:interval, OID::Interval, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:jsonb, OID::Jsonb, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:money, OID::Money, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:point, OID::Point, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:legacy_point, OID::LegacyPoint, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:uuid, OID::Uuid, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:vector, OID::Vector, adapter: :postgresql_proxy)
+      ActiveRecord::Type.register(:xml, OID::Xml, adapter: :postgresql_proxy)
     end
+    ActiveSupport.run_load_hooks(:active_record_postgresqlproxyadapter, PostgreSQLProxyAdapter)
   end
 end
 

--- a/lib/active_record/connection_adapters/trilogy_proxy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_proxy_adapter.rb
@@ -26,7 +26,17 @@ module ActiveRecord
       private
 
       attr_reader :proxy
+      ActiveRecord::Type.register(:immutable_string, adapter: :trilogy_proxy) do |_, **args|
+        Type::ImmutableString.new(true: "1", false: "0", **args)
+      end
+
+      ActiveRecord::Type.register(:string, adapter: :trilogy_proxy) do |_, **args|
+        Type::String.new(true: "1", false: "0", **args)
+      end
+
+      ActiveRecord::Type.register(:unsigned_integer, Type::UnsignedInteger, adapter: :trilogy_proxy)
     end
+    ActiveSupport.run_load_hooks(:active_record_trilogyproxyadapter, TrilogyProxyAdapter)
   end
 end
 


### PR DESCRIPTION
this fix for this issue https://github.com/Nasdaq/active_record_proxy_adapters/issues/33
when i check PostgreSQLAdapter class i found this registrations in it so when i add this registrations the error was fixed
maybe there is a better way to handle this.
let me know if there are any thing required from my side.