### PR TITLE
Remove postgresql requires from hijackable concern

### DIFF
--- a/lib/active_record_proxy_adapters/hijackable.rb
+++ b/lib/active_record_proxy_adapters/hijackable.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "active_record/tasks/postgresql_proxy_database_tasks"
-require "active_record/connection_adapters/postgresql_adapter"
-
 module ActiveRecordProxyAdapters
   # Defines mixins to delegate specific methods from the proxy to the adapter.
   module Hijackable


### PR DESCRIPTION
This concern is database agnostic and should no longer require any database specific constants since the introduction of mysql.

Fixes #51.