### PR TITLE
Add Context API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add support for configuring a Context API
+
 ## [0.6.1, 0.5.1, 0.4.7] - 2025-06-27
 
 - Bypass proxy when opening a transaction in ActiveRecord 7.0.x [d03adf6](https://github.com/Nasdaq/active_record_proxy_adapters/commit/d03adf61e284cc29f82879aefc4f087a91e01d33)

--- a/lib/active_record_proxy_adapters/context.rb
+++ b/lib/active_record_proxy_adapters/context.rb
@@ -1,14 +1,26 @@
 # frozen_string_literal: true
 
+require "active_record_proxy_adapters/mixin/configuration"
+
 module ActiveRecordProxyAdapters
   # Context is a simple class that holds a registry of connection names and their last write timestamps.
   # It is used to track the last time a write operation was performed on each connection.
   # This allows the proxy to determine whether to route read requests to the primary or replica database
   class Context
+    include Mixin::Configuration
+
     # @param hash [Hash] A hash containing the connection names as keys and the last write timestamps as values.
     #   Can be empty.
     def initialize(hash)
       @timestamp_registry = hash.transform_values(&:to_f)
+    end
+
+    def recent_write_to_primary?(connection_name)
+      now - self[connection_name] < proxy_delay
+    end
+
+    def update_for(connection_name)
+      self[connection_name] = now
     end
 
     def [](connection_name)
@@ -22,5 +34,9 @@ module ActiveRecordProxyAdapters
     private
 
     attr_reader :timestamp_registry
+
+    def now
+      Time.now.utc.to_f
+    end
   end
 end

--- a/lib/active_record_proxy_adapters/context.rb
+++ b/lib/active_record_proxy_adapters/context.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ActiveRecordProxyAdapters
+  class Context # rubocop:disable Style/Documentation
+    # @param hash [Hash] A hash containing the connection names as keys and the last write timestamps as values.
+    # Can be empty.
+    def initialize(hash)
+      @timestamp_registry = hash.transform_values(&:to_f)
+    end
+
+    def [](connection_name)
+      timestamp_registry[connection_name] || 0
+    end
+
+    def []=(connection_name, timestamp)
+      timestamp_registry[connection_name] = timestamp
+    end
+
+    private
+
+    attr_reader :timestamp_registry
+  end
+end

--- a/lib/active_record_proxy_adapters/context.rb
+++ b/lib/active_record_proxy_adapters/context.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 module ActiveRecordProxyAdapters
-  class Context # rubocop:disable Style/Documentation
+  # Context is a simple class that holds a registry of connection names and their last write timestamps.
+  # It is used to track the last time a write operation was performed on each connection.
+  # This allows the proxy to determine whether to route read requests to the primary or replica database
+  class Context
     # @param hash [Hash] A hash containing the connection names as keys and the last write timestamps as values.
-    # Can be empty.
+    #   Can be empty.
     def initialize(hash)
       @timestamp_registry = hash.transform_values(&:to_f)
     end

--- a/lib/active_record_proxy_adapters/contextualizer.rb
+++ b/lib/active_record_proxy_adapters/contextualizer.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
 module ActiveRecordProxyAdapters
-  module Contextualizer # rubocop:disable Style/Documentation
+  # A mixin for managing the context of current database connections.
+  module Contextualizer
     module_function
 
     # @return [ActiveRecordProxyAdapters::Context]
-    # Retrieves the current context for the thread.
+    # Retrieves the context for the current thread.
     def current_context
       Thread.current.thread_variable_get(:arpa_context)
     end
 
     # @param context [ActiveRecordProxyAdapters::Context]
-    # Sets the current context for the thread.
+    # Sets the context for the current thread.
     def current_context=(context)
       Thread.current.thread_variable_set(:arpa_context, context)
     end

--- a/lib/active_record_proxy_adapters/contextualizer.rb
+++ b/lib/active_record_proxy_adapters/contextualizer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ActiveRecordProxyAdapters
+  module Contextualizer # rubocop:disable Style/Documentation
+    module_function
+
+    # @return [ActiveRecordProxyAdapters::Context]
+    # Retrieves the current context for the thread.
+    def current_context
+      Thread.current.thread_variable_get(:arpa_context)
+    end
+
+    # @param context [ActiveRecordProxyAdapters::Context]
+    # Sets the current context for the thread.
+    def current_context=(context)
+      Thread.current.thread_variable_set(:arpa_context, context)
+    end
+  end
+end

--- a/lib/active_record_proxy_adapters/mixin/configuration.rb
+++ b/lib/active_record_proxy_adapters/mixin/configuration.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/integer/time"
+require "active_record_proxy_adapters/synchronizable_configuration"
+require "active_record_proxy_adapters/cache_configuration"
+require "active_record_proxy_adapters/context"
+
+module ActiveRecordProxyAdapters
+  module Mixin
+    # Provides helpers to access to reduce boilerplate while retrieving configuration properties.
+    module Configuration
+      # Helper to retrieve the proxy delay from the configuration stored in
+      # {ActiveRecordProxyAdapters::Configuration#proxy_delay}.
+      # @return [ActiveSupport::Duration]
+      def proxy_delay
+        proxy_config.proxy_delay
+      end
+
+      # Helper to retrieve the checkout timeout from the configuration stored in
+      # {ActiveRecordProxyAdapters::Configuration#checkout_timeout}.
+      # @return [ActiveSupport::Duration]
+      def checkout_timeout
+        proxy_config.checkout_timeout
+      end
+
+      # Helper to retrieve the context store class from the configuration stored in
+      # {ActiveRecordProxyAdapters::Configuration#context_store}.
+      # @return [Class]
+      def context_store
+        proxy_config.context_store
+      end
+
+      # Helper to retrieve the cache store from the configuration stored in
+      # {ActiveRecordProxyAdapters::CacheConfiguration#store}.
+      # @return [ActiveSupport::Cache::Store]
+      def cache_store
+        cache_config.store
+      end
+
+      # Helper to retrieve the cache key prefix from the configuration stored in
+      # {ActiveRecordProxyAdapters::CacheConfiguration#key_prefix}.
+      # It uses the key builder to generate a cache key for the given SQL string, prepended with the key prefix.
+      # @return [String]
+      def cache_key_for(sql_string)
+        cache_config.key_builder.call(sql_string).prepend(cache_config.key_prefix)
+      end
+
+      # @!visibility private
+      def cache_config
+        proxy_config.cache
+      end
+
+      # @!visibility private
+      def proxy_config
+        ActiveRecordProxyAdapters.config
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,6 +75,10 @@ RSpec.configure do |config|
     ActiveSupport.on_load(:active_record) { TestHelper.setup_active_record_config }
   end
 
+  config.before do
+    ActiveRecordProxyAdapters::Contextualizer.current_context = ActiveRecordProxyAdapters.config.context_store.new({})
+  end
+
   wrap_test_case_in_transaction = proc do |example|
     connection = ActiveRecord::Base.connection
 


### PR DESCRIPTION
# Context API for Primary/Replica Database Routing

## Summary

This pull request introduces a new Context API that provides an extensible way of routing between primary and replica databases. Nothing should change in behaviour with this change. It is the groundwork for a Rack middleware coming up in a follow-up PR.

## Key Changes

- Added a configurable `context_store` to track database write timestamps
- Created thread-safe context management for database connection state
- Added configuration helpers in a dedicated `Configuration` mixin

## Implementation Details

### New Files

- `context.rb`: Core `Context` class that maintains a registry of connection names and their last write timestamps
- `contextualizer.rb`: Module for managing thread-local context state
- `mixin/configuration.rb`: Shared configuration helpers to reduce code duplication

### Modified Files

- `configuration.rb`: Added `context_store` attribute with appropriate accessor methods
- `primary_replica_proxy.rb`: Refactored to use the Context API for routing decisions
- `spec_helper.rb`: Reset context between tests to ensure test isolation