### PR TITLE
Add Rack Middleware to store database writes per session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - Add support for configuring a Context API
+- Add Rack middleware to store context in session
 
 ## [0.6.2, 0.5.2, 0.4.8] - 2025-07-21
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activerecord (>= 7.0.0, < 8.1)
       activesupport (>= 7.0.0, < 8.1)
       digest (>= 3.1.0)
+      json
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_record_proxy_adapters (0.6.1)
+    active_record_proxy_adapters (0.6.2)
       activerecord (>= 7.0.0, < 8.1)
       activesupport (>= 7.0.0, < 8.1)
       digest (>= 3.1.0)

--- a/active_record_proxy_adapters.gemspec
+++ b/active_record_proxy_adapters.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", rails_version_restrictions
   spec.add_dependency "activesupport", rails_version_restrictions
   spec.add_dependency "digest", ">= 3.1.0"
+  spec.add_dependency "json"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/active_record_proxy_adapters/context.rb
+++ b/lib/active_record_proxy_adapters/context.rb
@@ -31,6 +31,10 @@ module ActiveRecordProxyAdapters
       timestamp_registry[connection_name] = timestamp
     end
 
+    def to_h
+      timestamp_registry.dup
+    end
+
     private
 
     attr_reader :timestamp_registry

--- a/lib/active_record_proxy_adapters/middleware.rb
+++ b/lib/active_record_proxy_adapters/middleware.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rack"
+require "json"
+require "active_record_proxy_adapters/context"
+require "active_record_proxy_adapters/contextualizer"
+require "active_record_proxy_adapters/mixin/configuration"
+
+module ActiveRecordProxyAdapters
+  class Middleware # rubocop:disable Style/Documentation
+    include Contextualizer
+    include Mixin::Configuration
+
+    COOKIE_NAME   = "arpa_context"
+    COOKIE_BUFFER = 5.seconds.freeze
+    DEFAULT_COOKIE_OPTIONS = {
+      path: "/",
+      http_only: true
+    }.freeze
+
+    class << self
+      include Mixin::Configuration
+    end
+
+    COOKIE_READER = lambda do |rack_env|
+      rack_request = Rack::Request.new(rack_env)
+      arpa_cookie  = rack_request.cookies[COOKIE_NAME]
+      JSON.parse(arpa_cookie || "{}")
+    rescue JSON::ParserError
+      {}
+    end.freeze
+
+    COOKIE_WRITER = lambda do |headers, cookie_hash, options|
+      cookie           = DEFAULT_COOKIE_OPTIONS.merge(options)
+      max_value        = cookie_hash.values.max || 0
+      then_time        = Time.at(max_value).utc
+      expires          = then_time + proxy_delay + COOKIE_BUFFER
+      max_age          = expires - then_time
+      cookie[:expires] = expires
+      cookie[:max_age] = max_age
+      cookie[:value]   = cookie_hash.to_json
+
+      Rack::Utils.set_cookie_header!(headers, COOKIE_NAME, cookie)
+    end.freeze
+
+    def initialize(app, cookie_options = {})
+      @app = app
+      @cookie_options = cookie_options
+    end
+
+    def call(env)
+      return @app.call(env) if ignore_request?(env)
+
+      self.current_context = context_store.new(COOKIE_READER.call(env))
+
+      status, headers, body = @app.call(env)
+
+      update_cookie_from_context(headers)
+
+      [status, headers, body]
+    end
+
+    private
+
+    def update_cookie_from_context(headers)
+      COOKIE_WRITER.call(headers, current_context.to_h, @cookie_options)
+    end
+
+    def ignore_request?(env)
+      return false unless defined?(Rails)
+      return false unless asset_prefix
+
+      /^#{asset_prefix}/.match?(env["PATH_INFO"].to_s)
+    end
+
+    def asset_prefix
+      Rails.try(:application).try(:config).try(:assets).try(:prefix)
+    end
+  end
+end

--- a/lib/active_record_proxy_adapters/primary_replica_proxy.rb
+++ b/lib/active_record_proxy_adapters/primary_replica_proxy.rb
@@ -233,7 +233,7 @@ module ActiveRecordProxyAdapters
     end
 
     def primary_connection_name
-      @primary_connection_name ||= primary_connection.pool.try(:db_config).try(:name).try(:to_sym)
+      @primary_connection_name ||= primary_connection.pool.try(:db_config).try(:name).try(:to_s)
     end
 
     def proxy_context

--- a/lib/active_record_proxy_adapters/railtie.rb
+++ b/lib/active_record_proxy_adapters/railtie.rb
@@ -6,6 +6,7 @@ module ActiveRecordProxyAdapters
   # Hooks into rails boot process to extend ActiveRecord with the proxy adapter.
   class Railtie < Rails::Railtie
     require "active_record_proxy_adapters/connection_handling"
+    require "active_record_proxy_adapters/middleware"
 
     config.to_prepare do
       Rails.autoloaders.each do |autoloader|
@@ -16,6 +17,10 @@ module ActiveRecordProxyAdapters
           "sqlite3_proxy_adapter" => "SQLite3ProxyAdapter"
         )
       end
+    end
+
+    initializer "active_record_proxy_adapters.configure_rails_initialization" do |app|
+      app.middleware.use ActiveRecordProxyAdapters::Middleware
     end
   end
 end

--- a/spec/active_record_proxy_adapters/middleware_spec.rb
+++ b/spec/active_record_proxy_adapters/middleware_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "active_record_proxy_adapters/middleware"
+require "cgi"
+
+RSpec.describe ActiveRecordProxyAdapters::Middleware do
+  def to_cookie_string(cookie_hash)
+    "#{cookie_name}=#{CGI.escape(cookie_hash.to_json)}; path=/; max-age=1"
+  end
+
+  def from_cookie_string(cookie_string)
+    cookie_properties = cookie_string.split(";").map(&:strip)
+    cookie_properties.each_with_object({}) do |property, cookie_hash|
+      key, value = property.split("=")
+
+      if key == "arpa_context"
+        cookie_hash["name"] = key
+        cookie_hash["value"] = JSON.parse(CGI.unescape(value))
+      else
+        cookie_hash[key] = value || true # cookie property without a value is treated as true
+      end
+    end
+  end
+
+  let(:user_model) do
+    Class.new(TestHelper::SQLite3Record) do
+      self.table_name = "users"
+    end
+  end
+
+  describe "#call" do
+    let(:middleware) { described_class.new(app, {}) }
+
+    let(:app) do
+      ->(env) { [200, {}, env[:query] || query] }
+    end
+    let(:query) { User.limit(1).to_a }
+    let(:cookie_name) { described_class::COOKIE_NAME }
+
+    before do
+      stub_const("User", user_model)
+
+      ActiveRecordProxyAdapters.configure do |config|
+        config.proxy_delay = 2.seconds
+      end
+
+      travel_to(Time.utc(2025))
+    end
+
+    after { travel_back }
+
+    context "when context cookie is not set" do
+      it "initializes the cookie with an empty hash" do
+        env = {}
+        _, headers, = middleware.call(env)
+
+        expect(headers["Set-Cookie"]).to include("arpa_context=#{CGI.escape("{}")}")
+      end
+    end
+
+    context "when context cookie is set" do
+      it "keeps cookie value from previous request" do
+        cookie_timestamp = Time.current.utc.to_f # 2025-01-01 00:00:00 UTC
+        cookie_hash      = { "sqlite3_primary" => cookie_timestamp }
+        env              = { "HTTP_COOKIE" => to_cookie_string(cookie_hash) }
+
+        _, headers, = middleware.call(env)
+
+        expect(from_cookie_string(headers["Set-Cookie"])["value"]).to eq(cookie_hash)
+      end
+    end
+
+    context "when query is a write" do
+      let(:query) { User.create!(name: SecureRandom.uuid, email: SecureRandom.uuid) }
+
+      it "updates the cookie expiry date" do
+        env = { "HTTP_COOKIE" => to_cookie_string({}) }
+
+        _, headers, = middleware.call(env)
+
+        cookie_expiry = from_cookie_string(headers["Set-Cookie"])["expires"]
+
+        expect(Time.parse(cookie_expiry)).to eq((2 + 5).seconds.from_now) # proxy delay + cookie buffer
+      end
+    end
+  end
+end

--- a/spec/benchmark/cache_store.rb
+++ b/spec/benchmark/cache_store.rb
@@ -32,13 +32,14 @@ module CacheStoreBenchmark
     VALUES ('John Doe', 'john.doe@gmail.com')
   SQL5
 
-  class User < TestHelper::PostgreSQLRecord
+  class PostgreSQLUser < TestHelper::PostgreSQLRecord
+    self.table_name = "users"
   end
 
   def run(cache_store, iterations: nil) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
     ActiveRecordProxyAdapters.configure { |config| config.cache.store = cache_store }
 
-    connection = User.connection
+    connection = PostgreSQLUser.connection
     proxy      = connection.send(:proxy)
 
     ActiveRecord::Base.logger ||= Logger.new($stdout)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require "simplecov_json_formatter"
 require "active_support/core_ext/object/blank"
 require "simple_cov_groups"
 require "active_record"
+require "active_support/testing/time_helpers"
 
 simple_cov_formatters = [SimpleCov::Formatter::JSONFormatter]
 simple_cov_formatters << SimpleCov::Formatter::HTMLFormatter unless ENV["CI"]
@@ -61,6 +62,7 @@ ActiveRecord::Base.logger = Logger.new(Tempfile.create)
 ENV["RAILS_ENV"] ||= TestHelper.env_name
 
 RSpec.configure do |config|
+  config.include(ActiveSupport::Testing::TimeHelpers)
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 


### PR DESCRIPTION
# Add Rack Middleware for Context Persistence

## Changes

This PR adds a new Rack middleware to store database write context information in the user's session, improving the primary/replica routing capabilities.

This will improve read-your-own-write consistency for applications that use a connection pooler, such as PgBouncer or RDS Proxy.

### Added

- **Rack Middleware**: A new `ActiveRecordProxyAdapters::Middleware` class that:
  - Stores database write timestamps in a secure HTTP-only cookie
  - Restores context between requests for consistent replica routing
  - Automatically expires outdated context data
  - Includes optimization to ignore asset requests in Rails apps

### Modified

- Added `to_h` method to `Context` class to support context serialization
- Updated primary connection name handling to use string instead of symbol format
- Configured the Railtie to automatically include the middleware in Rails apps
- Added JSON as a dependency for cookie serialization