### PR TITLE
Load core files from library root

### DIFF
--- a/lib/active_record_proxy_adapters.rb
+++ b/lib/active_record_proxy_adapters.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require "active_record"
-require "active_record_proxy_adapters/version"
-require "active_record_proxy_adapters/configuration"
+require "active_record_proxy_adapters/core"
 
 # The gem namespace.
 module ActiveRecordProxyAdapters

--- a/lib/active_record_proxy_adapters/core.rb
+++ b/lib/active_record_proxy_adapters/core.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_record"
+require "active_record_proxy_adapters/version"
 require "active_record_proxy_adapters/active_record_context"
 require "active_record_proxy_adapters/configuration"
 require "active_record_proxy_adapters/context"


### PR DESCRIPTION
This is part of a broader number of changes which will allow requiring adapter-specific files for a lightweight bootstrap of the application using this gem.

Relates to #83 