### PR TITLE
Fix circular require warning

### DIFF
--- a/lib/active_record_proxy_adapters/mixin/configuration.rb
+++ b/lib/active_record_proxy_adapters/mixin/configuration.rb
@@ -3,7 +3,6 @@
 require "active_support/core_ext/integer/time"
 require "active_record_proxy_adapters/synchronizable_configuration"
 require "active_record_proxy_adapters/cache_configuration"
-require "active_record_proxy_adapters/context"
 
 module ActiveRecordProxyAdapters
   module Mixin


### PR DESCRIPTION
Hi, thanks for this gem!

This fixes a circular require warning when Ruby warnings are turned on:

```text
<internal:/Users/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136: warning: <internal:/Users/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136: warning: loading in progress, circular require considered harmful - /Users/user/.rbenv/versions/3.4.6/lib/ruby/gems/3.4.0/gems/active_record_proxy_adapters-0.8.0/lib/active_record_proxy_adapters/context.rb
    from -e:1:in  '<main>'
    from <internal:/Users/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:135:in  'require'
    from <internal:/Users/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:141:in  'rescue in require'
    from <internal:/Users/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:141:in  'require'
    from /Users/user/.rbenv/versions/3.4.6/lib/ruby/gems/3.4.0/gems/active_record_proxy_adapters-0.8.0/lib/active_record_proxy_adapters.rb:5:in  '<top (required)>'
    from <internal:/Users/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in  'require'
    from <internal:/Users/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in  'require'
    from /Users/user/.rbenv/versions/3.4.6/lib/ruby/gems/3.4.0/gems/active_record_proxy_adapters-0.8.0/lib/active_record_proxy_adapters/configuration.rb:4:in  '<top (required)>'
    from <internal:/Users/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in  'require'
    from <internal:/Users/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in  'require'
    from /Users/user/.rbenv/versions/3.4.6/lib/ruby/gems/3.4.0/gems/active_record_proxy_adapters-0.8.0/lib/active_record_proxy_adapters/context.rb:3:in  '<top (required)>'
    from <internal:/Users/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in  'require'
    from <internal:/Users/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in  'require'
    from /Users/user/.rbenv/versions/3.4.6/lib/ruby/gems/3.4.0/gems/active_record_proxy_adapters-0.8.0/lib/active_record_proxy_adapters/mixin/configuration.rb:6:in  '<top (required)>'
    from <internal:/Users/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in  'require'
    from <internal:/Users/user/.rbenv/versions/3.4.6/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in  'require'
```

To reproduce:

```sh
ruby -w -e 'require "active_record_proxy_adapters"'
```