### PR TITLE
Fix connection stickiness for inserts with Trilogy, take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Move loading of Mysql2Proxy to its own Railtie
 - Move loading of TrilogyProxy to its own Railtie
 - Move loading of SQLite3Proxy to its own Railtie
+- Fix connection stickiness for inserts with Trilogy
 
 ## [0.8.0] - 2025-08-28
 

--- a/lib/active_record/connection_adapters/trilogy_proxy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_proxy_adapter.rb
@@ -21,7 +21,7 @@ module ActiveRecord
 
       ADAPTER_NAME = "TrilogyProxy"
 
-      delegate_to_proxy(*ActiveRecordProxyAdapters::ActiveRecordContext.hijackable_methods)
+      delegate_to_proxy(*ActiveRecordProxyAdapters::ActiveRecordContext.hijackable_methods, :exec_insert)
 
       def initialize(...)
         @proxy = ActiveRecordProxyAdapters::TrilogyProxy.new(self)

--- a/lib/active_record_proxy_adapters/active_record_context.rb
+++ b/lib/active_record_proxy_adapters/active_record_context.rb
@@ -38,7 +38,7 @@ module ActiveRecordProxyAdapters
     end
 
     def hijackable_methods
-      hijackable = %i[execute exec_query exec_insert]
+      hijackable = %i[execute exec_query]
 
       hijackable << :internal_exec_query if active_record_v7_1_or_greater?
 

--- a/lib/active_record_proxy_adapters/trilogy_proxy.rb
+++ b/lib/active_record_proxy_adapters/trilogy_proxy.rb
@@ -5,5 +5,6 @@ require "active_record_proxy_adapters/mysql2_proxy"
 module ActiveRecordProxyAdapters
   # Proxy to the Mysql2Proxy, allowing the use of the ActiveRecordProxyAdapters::PrimaryReplicaProxy.
   class TrilogyProxy < Mysql2Proxy
+    hijack_method :exec_insert
   end
 end


### PR DESCRIPTION
This is an alternate version of #139 that only overrides `exec_insert` for Trilogy.

The initial version causes unnecessary calls to `appropriate_connection` for other adapters.