### PR TITLE
Load core files from railties

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Install the gem and add to the application's Gemfile by executing:
 
     $ bundle add 'active_record_proxy_adapters'
 
+That will install and load the proxies for all Rails-supported adapters (i.e. `postgresql_proxy`, `mysql2_proxy`, `sqlite3_proxy` and `trilogy_proxy`).
+
+If you wish to load only one specific adapter for a faster application boot, use:
+
+    $ bundle add 'active_record_proxy_adapters' --require 'active_record_proxy_adapters/railties/<postgresql|mysql2|sqlite3|trilogy>'
+
+Or, in your Gemfile, use:
+
+```ruby
+  gem "active_record_proxy_adapters", require: 'active_record_proxy_adapters/railties/<postgresql|mysql2|sqlite3|trilogy>'
+```
+
 If bundler is not being used to manage dependencies, install the gem by executing:
 
     $ gem install active_record_proxy_adapters

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,7 @@ desc "Prepares the database environment for use"
 task :environment do
   $LOAD_PATH << File.expand_path("lib", __dir__)
   require "active_record_proxy_adapters"
+  require "active_record_proxy_adapters/core"
   require_relative "spec/test_helper"
 
   require "active_record_proxy_adapters/connection_handling"

--- a/lib/active_record_proxy_adapters.rb
+++ b/lib/active_record_proxy_adapters.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_record_proxy_adapters/core"
-
 # The gem namespace.
 module ActiveRecordProxyAdapters
 end

--- a/lib/active_record_proxy_adapters/railtie.rb
+++ b/lib/active_record_proxy_adapters/railtie.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support"
+require "active_record_proxy_adapters/core"
 require "active_record_proxy_adapters/railties/postgresql"
 require "active_record_proxy_adapters/railties/mysql2"
 require "active_record_proxy_adapters/railties/trilogy"

--- a/lib/active_record_proxy_adapters/railties/mysql2.rb
+++ b/lib/active_record_proxy_adapters/railties/mysql2.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support"
+require "active_record_proxy_adapters/core"
 
 module ActiveRecordProxyAdapters
   module Railties

--- a/lib/active_record_proxy_adapters/railties/postgresql.rb
+++ b/lib/active_record_proxy_adapters/railties/postgresql.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support"
+require "active_record_proxy_adapters/core"
 
 module ActiveRecordProxyAdapters
   module Railties

--- a/lib/active_record_proxy_adapters/railties/sqlite3.rb
+++ b/lib/active_record_proxy_adapters/railties/sqlite3.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support"
+require "active_record_proxy_adapters/core"
 
 module ActiveRecordProxyAdapters
   module Railties

--- a/lib/active_record_proxy_adapters/railties/trilogy.rb
+++ b/lib/active_record_proxy_adapters/railties/trilogy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support"
+require "active_record_proxy_adapters/core"
 
 module ActiveRecordProxyAdapters
   module Railties

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ SimpleCov.start do
 end
 
 require "active_record_proxy_adapters"
+require "active_record_proxy_adapters/core"
 
 require "active_record_proxy_adapters/connection_handling"
 ActiveSupport.on_load(:active_record) do


### PR DESCRIPTION
This allows each railtie to be loaded independently, which is useful for faster application boot when you only need to load a specific adapter vs all adapters.