### PR TITLE
Fix cross-pool replica checkin when :reading pool_config is swapped mid-flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add Ruby 4.0.0 to test matrix
 - Hijack only higher-level active record adapter methods [1d7eae3](https://github.com/Nasdaq/active_record_proxy_adapters/commit/1d7eae3a9c7a75cc4adebe64a1fdc1289205bfe)
 - Add ActiveRecord model integration tests [2ab16e1](https://github.com/Nasdaq/active_record_proxy_adapters/commit/2ab16e196410b9985d29a976fb64d58171f483e3)
+- Fix cross-pool replica checkin when `:reading` pool_config is swapped mid-flight [58a52a0](https://github.com/Nasdaq/active_record_proxy_adapters/commit/58a52a0)
 
 ## [0.10.2, 0.9.3] - 2026-02-26
 - Fix middleware context thread variable leak [9f175ff](https://github.com/Nasdaq/active_record_proxy_adapters/commit/9f175ff092151a05b832b0c380e04b32ffc02bde)

--- a/lib/active_record_proxy_adapters/primary_replica_proxy.rb
+++ b/lib/active_record_proxy_adapters/primary_replica_proxy.rb
@@ -174,7 +174,14 @@ module ActiveRecordProxyAdapters
 
       result
     ensure
-      replica_connection?(connection) && replica_pool.checkin(connection)
+      # Check the connection back into its own pool, not whatever pool currently
+      # answers to the :reading role. In Rails system tests,
+      # ActiveRecord::TestFixtures#setup_shared_connection_pool reassigns the
+      # :reading role's pool_config on every transactional-fixture test's
+      # before_setup, so re-resolving `replica_pool` here can return a pool
+      # different from the one the connection was checked out of — which would
+      # check a replica adapter into the primary pool and poison it.
+      connection.pool.checkin(connection) if replica_connection?(connection)
     end
 
     def connected_to(role:, &block)

--- a/spec/active_record_proxy_adapters/primary_replica_proxy_spec.rb
+++ b/spec/active_record_proxy_adapters/primary_replica_proxy_spec.rb
@@ -40,17 +40,22 @@ RSpec.describe ActiveRecordProxyAdapters::PrimaryReplicaProxy do
       end
 
       before do
-        # Simulate `setup_shared_connection_pool` firing between the proxy's
-        # checkout_replica_connection and the ensure-block `replica_pool.checkin`.
-        # The proxy calls `replica_pool` more than once per `connection_for` — we
-        # return the real replica pool for the checkout-side calls and the primary
-        # pool for the final checkin call, which is exactly what a mid-flight
-        # pool_config swap produces.
+        # A single `connection_for` resolves `replica_pool` twice on the
+        # checkout side:
+        #   1. `replica_pool_unavailable?` — to decide whether to use a replica
+        #   2. `checkout_replica_connection` — for `replica_pool.checkout`
+        # Any subsequent resolution would be the ensure-block re-resolving the
+        # pool to check the connection back in — which is exactly the call that
+        # `setup_shared_connection_pool` corrupts when it swaps the :reading
+        # pool_config between checkout and checkin. We reproduce that swap by
+        # returning the real replica pool for the two checkout-side calls and
+        # the primary pool for anything after.
+        checkout_side_calls = 2
         call_count = 0
         allow(proxy).to receive(:replica_pool).and_wrap_original do |original, *args, **kwargs|
           call_count += 1
-          last_call = call_count >= 3
-          last_call ? primary_pool : original.call(*args, **kwargs)
+          after_checkout = call_count > checkout_side_calls
+          after_checkout ? primary_pool : original.call(*args, **kwargs)
         end
       end
 

--- a/spec/active_record_proxy_adapters/primary_replica_proxy_spec.rb
+++ b/spec/active_record_proxy_adapters/primary_replica_proxy_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe ActiveRecordProxyAdapters::PrimaryReplicaProxy do
+  describe "#connection_for" do
+    # In Rails' system tests, ActiveRecord::TestFixtures#setup_shared_connection_pool
+    # reassigns the :reading role's pool_config to the :writing pool_config on every
+    # transactional-fixture test's before_setup. Because PrimaryReplicaProxy resolves
+    # `replica_pool` on every call via retrieve_connection_pool(..., role: :reading),
+    # a swap that occurs between the initial checkout (in #checkout_replica_connection)
+    # and the ensure-block checkin causes the replica connection to be checked into
+    # the wrong (primary) pool, where a later ConnectionPool#pin_connection! picks it
+    # up as the fixture-transaction connection and every subsequent write on the
+    # primary class raises ActiveRecord::ReadOnlyError.
+    #
+    # This spec exercises that race deterministically: we stub `replica_pool` on the
+    # proxy to return the real replica pool on the checkout call and the primary pool
+    # on the ensure-block call, mirroring what the handler does when
+    # setup_shared_connection_pool runs mid-SELECT. After the query completes, the
+    # connection must still land in its original (replica) pool, not the primary pool.
+    context "when the :reading pool_config is reassigned between checkout and the ensure-block checkin" do
+      subject(:run_query) { proxy.execute(sql) }
+
+      let(:primary_pool) { TestHelper.sqlite3_primary_pool }
+      let(:replica_pool) { TestHelper.sqlite3_replica_pool }
+      let(:proxy) { ActiveRecordProxyAdapters::SQLite3Proxy.new(primary_adapter) }
+      let(:sql) { "SELECT 1" }
+
+      around do |example|
+        primary_pool.with_connection do |connection|
+          @primary_adapter = connection
+          example.run
+          @primary_adapter = nil
+        end
+      end
+
+      attr_reader :primary_adapter
+
+      def primary_available_connections
+        primary_pool.instance_variable_get(:@available).instance_variable_get(:@queue)
+      end
+
+      before do
+        # Simulate `setup_shared_connection_pool` firing between the proxy's
+        # checkout_replica_connection and the ensure-block `replica_pool.checkin`.
+        # The proxy calls `replica_pool` more than once per `connection_for` — we
+        # return the real replica pool for the checkout-side calls and the primary
+        # pool for the final checkin call, which is exactly what a mid-flight
+        # pool_config swap produces.
+        call_count = 0
+        allow(proxy).to receive(:replica_pool).and_wrap_original do |original, *args, **kwargs|
+          call_count += 1
+          last_call = call_count >= 3
+          last_call ? primary_pool : original.call(*args, **kwargs)
+        end
+      end
+
+      it "does not leave the replica connection in the primary pool" do
+        run_query
+
+        leaked = primary_available_connections.find { |c| c.respond_to?(:replica?) && c.replica? }
+
+        expect(leaked).to be_nil, "replica adapter leaked into the primary pool (#{leaked.inspect})"
+      end
+    end
+  end
+end

--- a/spec/shared_examples/a_sql_statement.rb
+++ b/spec/shared_examples/a_sql_statement.rb
@@ -12,7 +12,7 @@ RSpec.shared_examples_for "a SQL read statement" do
   end
 
   it "checks replica connection back in to the pool" do
-    conn = instance_double(adapter_class, method_name => nil)
+    conn = instance_double(adapter_class, method_name => nil, pool: replica_pool)
     allow(replica_pool).to receive(:checkout).and_return(conn)
     allow(replica_pool).to receive(:checkin)
 


### PR DESCRIPTION
## Background

NOTE: This Background section was written by nbrustein. Everything below here, and all of the code in this PR, was written by Claude.

In a rails project with a lot of capybara tests using transactional fixtures, we intermittently see the following error when running tests in CircleCI:

```
Write query attempted while in readonly mode: INSERT INTO...
```

In working back and forth with a Claude agent, I managed to create tests that reliably reproduced the issue both in our project and in this project as well. I've confirmed that the fix makes those tests pass, and I haven't yet seen the issue pop back up on CircleCI in our project. But, given the flaky nature of the failure, it's hard to be 100% sure of the reliability of the fix just yet.

## Problem

`PrimaryReplicaProxy#connection_for` resolves `replica_pool` lazily on every call via `connection_handler.retrieve_connection_pool(..., role: :reading)`, and its `ensure` block calls `replica_pool.checkin(connection)`. Because the lookup happens twice (once at checkout, once at checkin), any mutation to what the `:reading` role resolves to between those two points causes the replica adapter to be checked into the *new* pool — not the pool it was checked out of.

Rails' `ActiveRecord::TestFixtures#setup_shared_connection_pool` does exactly this mutation: it reassigns the `:reading` pool_config to the `:writing` pool_config on every transactional-fixture test's `before_setup`, so the test thread and the Puma thread can see each other's in-transaction changes. Under normal, single-threaded test operation this is fine, because `connection_for` runs synchronously: checkout and checkin happen with the same pool.

In Rails system tests (Capybara/Puma), there is a second thread. When a Puma-side SELECT is mid-flight and the test thread enters the next test's `before_setup` and calls `setup_shared_connection_pool`, the race is:

1. Puma thread: `connection_for` → `checkout_replica_connection` → `replica_pool.checkout(...)` returns a real replica adapter. `replica_pool` here resolves to the primary_replica pool.
2. Test thread: `setup_shared_connection_pool` reassigns `:reading` → primary pool_config.
3. Puma thread: ensure block fires → `replica_pool.checkin(connection)`. Now `replica_pool` resolves to the **primary** pool. The replica adapter is added to the primary pool's `@available`.
4. Next test: `setup_transactional_fixtures` → `primary_pool.pin_connection!` → `checkout` → pops the replica adapter from `@available`, pins it, begins the fixture transaction.
5. Every write on the primary class in that test (and every test after it in the process) calls through the pinned connection, whose `replica?` is `true`, so `preventing_writes?` is `true`, so `ensure_writes_are_allowed` raises `ActiveRecord::ReadOnlyError` — on `INSERT`, `UPDATE`, any write. The state is sticky to the process, so the whole rest of the run fails identically.

We hit this in CI on a Rails 8.1.1 app (`active_record_proxy_adapters 0.10.1`, mysql2, `RDS_USE_READ_REPLICAS=true`). Intermittent — depends on the exact interleaving of the Puma SELECT and the test thread's `before_setup`. The failing query is always an `INSERT` from the app's per-test setup (team/company bootstrap), raising `ActiveRecord::ReadOnlyError: Write query attempted while in readonly mode`.

## Fix

Check the connection back into its own pool rather than whatever pool currently answers to the `:reading` role. The `AbstractAdapter` instance retains a reference to the pool that created it (`connection.pool`), and that reference is immutable for the life of the adapter. Using it here makes the checkin path independent of any subsequent pool_config reassignment.

```ruby
ensure
  connection.pool.checkin(connection) if replica_connection?(connection)
end
```

The change is in `lib/active_record_proxy_adapters/primary_replica_proxy.rb`.

## Test

Added `spec/active_record_proxy_adapters/primary_replica_proxy_spec.rb` which exercises `connection_for` after stubbing `replica_pool` to return the real replica pool on checkout and the primary pool on the ensure-block lookup — exactly what `setup_shared_connection_pool` produces mid-flight. The assertion is that no replica adapter ends up in the primary pool's `@available`.

- Pre-fix: spec fails with "replica adapter leaked into the primary pool (id=..., class=SQLite3Adapter)".
- Post-fix: spec passes.

The spec targets sqlite3 so it runs in the non-integration job without needing the postgres/mysql replica containers.

## Adjusted shared example

The existing shared example "checks replica connection back in to the pool" (`spec/shared_examples/a_sql_statement.rb`) stubs the connection with `instance_double(adapter_class, method_name => nil)`. With the fix, the ensure block calls `connection.pool.checkin(connection)`, so the double must now expose `pool`. Adding `pool: replica_pool` to the `instance_double` keeps the test's semantics (the checkin still targets `replica_pool`) while making it work with the fixed code path.

## How to reproduce locally

```
BUNDLE_GEMFILE=gemfiles/ar_8.1.gemfile RAILS_ENV=test \
  bundle exec rspec spec/active_record_proxy_adapters/primary_replica_proxy_spec.rb
```

(Needs a local sqlite3 database per the AR 8.1 gemfile — `bundle exec rake db:create:sqlite3 db:schema:load:sqlite3` the first time.)

