### PR TITLE
Normalize commented SQL before proxy routing

### DIFF
--- a/lib/active_record_proxy_adapters/primary_replica_proxy.rb
+++ b/lib/active_record_proxy_adapters/primary_replica_proxy.rb
@@ -43,6 +43,7 @@ module ActiveRecordProxyAdapters
       /(\A|\s+?)DELETE\s+?FROM\s+?\S+?/i,
       /(\A|\s+?)DROP\s/i
     ].map(&:freeze).freeze
+    LEADING_SQL_COMMENTS = %r{\A(?:\s|/\*.*?\*/|--[^\r\n]*(?:\r\n?|\n|\z))*}m
 
     # Abstract adapter methods that should be proxied.
     hijack_method(*ActiveRecordContext.hijackable_methods)
@@ -103,7 +104,10 @@ module ActiveRecordProxyAdapters
 
     def coerce_query_to_string(sql_or_arel)
       # TODO: implement custom Proxy arel parser
-      sql_or_arel.respond_to?(:to_sql) ? sql_or_arel.to_sql(connection_class) : sql_or_arel.to_s
+      sql_string = sql_or_arel.respond_to?(:to_sql) ? sql_or_arel.to_sql(connection_class) : sql_or_arel.to_s
+      normalized_sql = sql_string.sub(LEADING_SQL_COMMENTS, "")
+      normalized_sql.rstrip!
+      normalized_sql
     end
 
     def appropriate_connection(sql_string, &block)

--- a/spec/active_record_proxy_adapters/primary_replica_proxy_spec.rb
+++ b/spec/active_record_proxy_adapters/primary_replica_proxy_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe ActiveRecordProxyAdapters::PrimaryReplicaProxy do
+  subject(:proxy) { described_class.new(primary_connection) }
+
+  let(:primary_connection) do
+    db_config = Struct.new(:name).new("primary")
+    pool = Struct.new(:db_config).new(db_config)
+    Struct.new(:pool).new(pool)
+  end
+
+  describe "SQL normalization" do
+    it "removes leading block and line comments" do
+      sql = " /* application:api */\r\n-- controller:index\r/* action:show */\nSELECT 1  "
+
+      expect(normalize(sql)).to eq("SELECT 1")
+    end
+
+    it "preserves comments and comment-like text inside the statement" do
+      sql = "/* query tag */ SELECT '/* literal */ -- literal' /* optimizer hint */"
+
+      expect(normalize(sql)).to eq("SELECT '/* literal */ -- literal' /* optimizer hint */")
+    end
+
+    it "routes a commented SELECT to the replica" do
+      expect(proxy.send(:need_primary?, normalize("/* query tag */ SELECT 1"))).to be(false)
+    end
+
+    it "sends a commented SET to all connections" do
+      expect(proxy.send(:need_all?, normalize("/* query tag */ SET statement_timeout = 1000"))).to be(true)
+    end
+
+    it "keeps a commented SET LOCAL on one connection" do
+      expect(proxy.send(:need_all?, normalize("/* query tag */ SET LOCAL statement_timeout = 1000"))).to be(false)
+    end
+
+    it "recognizes a commented INSERT as a write" do
+      sql = normalize("/* query tag */ INSERT INTO users (name) VALUES ('Jane')")
+
+      expect(proxy.send(:write_statement?, sql)).to be(true)
+    end
+  end
+
+  def normalize(sql)
+    proxy.send(:coerce_query_to_string, sql)
+  end
+end


### PR DESCRIPTION
## Summary

Rails query-log tags prepend comments to SQL statements. Because the proxy classifies statements from the beginning of the SQL string, those comments can prevent reads, writes, and `SET` statements from being recognized correctly.

This change normalizes SQL once before routing and caching:

- Removes leading whitespace, block comments, and line comments.
- Preserves comments and comment-like text inside the actual statement.
- Restores correct read routing, write stickiness, and `SET` / `SET LOCAL` handling when query-log tags are enabled.

## Verification

- Added focused specs for block comments, line comments, literals, reads, writes, `SET`, and `SET LOCAL`.
- Targeted RuboCop passes with no offenses.
- Ruby syntax and isolated routing checks pass.

