### PR TITLE
Respect outer connection roles through unrelated nested blocks

### DIFF
--- a/lib/active_record_proxy_adapters/primary_replica_proxy.rb
+++ b/lib/active_record_proxy_adapters/primary_replica_proxy.rb
@@ -135,17 +135,17 @@ module ActiveRecordProxyAdapters
     end
 
     def top_of_connection_stack_role
-      return if connected_to_stack.empty?
+      connected_to_stack.reverse_each do |entry|
+        role, klasses = entry.values_at(:role, :klasses)
+        next unless role.present?
 
-      top = connected_to_stack.last
-      role, klasses = top.values_at(:role, :klasses)
-      return unless role.present?
+        # A nested block for another connection class must not hide this class's role.
+        next unless klasses.include?(connection_class) || klasses.include?(ActiveRecord::Base)
 
-      # ActiveRecord::Base is the parent record for all models so,
-      # if the top of the stack includes it, we should respect it.
-      role_for_current_class = klasses.include?(connection_class) || klasses.include?(ActiveRecord::Base)
+        return [reading_role, writing_role].include?(role) ? role : nil
+      end
 
-      [reading_role, writing_role].include?(role) && role_for_current_class ? role : nil
+      nil
     end
 
     def connected_to_stack


### PR DESCRIPTION
## Summary

- Preserve an explicit outer connection role when a nested `connected_to` block belongs to another connection class.
- Skip shard-only frames and use the nearest applicable role, matching Active Record's stack lookup order.
- Keep automatic routing when there is no applicable role or the nearest applicable role is unsupported.

The current implementation checks only the last stack entry. For `Primary.connected_to(role: :writing) { Other.connected_to(role: :reading) { ... } }`, Active Record reports `Primary.current_role == :writing`, but the proxy returns `nil` and may automatically route a SELECT to the replica. This extends the class scoping introduced in #120; it does not change replica checkout behavior or SQL normalization.

## Reproduction (no database required)

```ruby
require 'active_record'
require 'active_record_proxy_adapters/core'
class Primary < ActiveRecord::Base
  self.abstract_class = true
  self.connection_class = true
end
class Other < ActiveRecord::Base
  self.abstract_class = true
  self.connection_class = true
end
proxy = ActiveRecordProxyAdapters::PrimaryReplicaProxy.new(nil)
proxy.define_singleton_method(:connection_class) { Primary }
Primary.connected_to(role: :writing) do
  Other.connected_to(role: :reading) do
    p [Primary.current_role, proxy.send(:top_of_connection_stack_role)]
  end
end
```

Before: `[:writing, nil]`. After: `[:writing, :writing]`.

## Verification

- Ruby 4.0.6: 15 focused role cases pass, including unrelated inner blocks, matching inner override, shard-only frames, Base-wide scope, unsupported role fallback, empty stack and stack cleanup.
- Existing upstream configuration/cache/middleware/SQLite proxy/integration specs: 78 examples pass with Active Record 7.2.3.1 and 78 with 8.1.3.1.
- Existing targeted RuboCop, Ruby syntax check, `git diff --check`, and gem build pass.
- The upstream root bundle omits sqlite3 despite configuring its adapter in spec setup. Used temporary external Gemfiles adding installed sqlite3 2.2.0; no checked-in Gemfile or test files changed. Initialized the existing SQLite fixture schema in the isolated checkout.

## Limitations and compatibility

- No PostgreSQL/MySQL replication suite or Linux execution was run locally. Upstream CI can cover the broader adapter/runtime matrix.
- No test files added or changed under the consumer's no-new-tests policy; reproduction and focused verification are included above.
- Checks ran on a v0.11.1-based consumer patch. This PR carries the identical source change on main, whose runtime source matches v0.11.1 except version.rb.
- **Breaking changes: none intended.** Explicit nested roles now remain effective where they were previously ignored. Public APIs, dependency requirements, and package version are unchanged.

Prepared with Codex assistance.
