### PR TITLE
Validate context cookie timestamps

### DIFF
--- a/lib/active_record_proxy_adapters/middleware.rb
+++ b/lib/active_record_proxy_adapters/middleware.rb
@@ -26,7 +26,16 @@ module ActiveRecordProxyAdapters
     COOKIE_READER = lambda do |rack_env|
       rack_request = Rack::Request.new(rack_env)
       arpa_cookie  = rack_request.cookies[COOKIE_NAME]
-      JSON.parse(arpa_cookie || "{}")
+      cookie_hash  = JSON.parse(arpa_cookie || "{}")
+      next {} unless cookie_hash.is_a?(Hash)
+
+      now = Time.now.utc.to_f
+      cookie_hash.each_with_object({}) do |(connection_name, value), context|
+        timestamp = Float(value, exception: false)
+        next unless timestamp&.finite? && timestamp >= 0
+
+        context[connection_name] = [timestamp, now].min
+      end
     rescue JSON::ParserError
       {}
     end.freeze


### PR DESCRIPTION
## Summary

- reject valid JSON cookies whose top-level value is not an object
- discard null, composite, negative, and non-finite timestamps
- preserve numeric-string compatibility and clamp future timestamps to the current server time

The context cookie is request input. Valid JSON such as `[]` or nested arrays/hashes currently raises during context construction, while an infinite timestamp raises when the response cookie is written. Future timestamps can also extend primary stickiness beyond the configured delay.

## Verification

- external model sanitizes 11 malformed/invalid cookie cases
- numeric-string compatibility, mixed-value filtering, and future clamping pass
- existing Rails 8.1.3.1 SQLite-focused suite: 78 examples, 0 failures
- targeted RuboCop and Ruby syntax pass
- exercised with Rack 2.2 in the upstream suite and Rack 3.2 in the external model

No test files or dependency metadata changed.

Created with Codex assistance.