### PR TITLE
Balance Rake connection stack frames

### DIFF
--- a/lib/active_record_proxy_adapters/rake.rb
+++ b/lib/active_record_proxy_adapters/rake.rb
@@ -5,6 +5,19 @@ require "rake"
 module ActiveRecordProxyAdapters
   # Enhances all rails db rake tasks to stick to writer connection
   module Rake
+    # Runs a database task's actions within a balanced writing-role stack frame.
+    module WriterConnectionTask
+      def execute(args = nil)
+        pushed = false
+        ActiveRecordProxyAdapters::Rake.push_to_stack_rake_task.execute
+        pushed = true
+
+        super
+      ensure
+        ActiveRecordProxyAdapters::Rake.pop_from_stack_rake_task.execute if pushed
+      end
+    end
+
     module_function
 
     def load_tasks
@@ -19,7 +32,7 @@ module ActiveRecordProxyAdapters
       ::Rake::Task
         .tasks
         .select(&enhanceable_db_task?)
-        .each { |task| task.enhance([push_to_stack_rake_task.name], &pop_from_stack_and_reenable) }
+        .each { |task| task.extend(WriterConnectionTask) }
     end
 
     def push_to_stack_rake_task
@@ -28,13 +41,6 @@ module ActiveRecordProxyAdapters
 
     def pop_from_stack_rake_task
       ::Rake::Task["arpa:pop_from_stack"]
-    end
-
-    def pop_from_stack_and_reenable
-      proc do
-        pop_from_stack_rake_task.invoke
-        [push_to_stack_rake_task, pop_from_stack_rake_task].each(&:reenable)
-      end
     end
 
     def enhanceable_db_task?

--- a/lib/active_record_proxy_adapters/tasks/arpa.rake
+++ b/lib/active_record_proxy_adapters/tasks/arpa.rake
@@ -12,14 +12,16 @@ namespace :arpa do
       klasses: [ActiveRecord::Base]
     }
 
-    Thread.current.thread_variable_set(:arpa_rake_pushed_to_stack, true)
+    depth = Thread.current.thread_variable_get(:arpa_rake_stack_depth).to_i
+    Thread.current.thread_variable_set(:arpa_rake_stack_depth, depth + 1)
   end
 
   desc "Pops from connected_to stack after rake task is invoked"
   task :pop_from_stack do
-    if Thread.current.thread_variable_get(:arpa_rake_pushed_to_stack)
+    depth = Thread.current.thread_variable_get(:arpa_rake_stack_depth).to_i
+    if depth.positive?
       ActiveRecord::Base.connected_to_stack.pop
-      Thread.current.thread_variable_set(:arpa_rake_pushed_to_stack, nil)
+      Thread.current.thread_variable_set(:arpa_rake_stack_depth, depth == 1 ? nil : depth - 1)
     end
   end
 end


### PR DESCRIPTION
## Summary
- wrap each database task action with exception-safe writer-stack setup and cleanup
- depth-count stack ownership so nested database tasks retain their outer writer frame
- make repeated enhancement idempotent without relying on shared Rake task invocation state

## Reproduction
The current implementation appends cleanup after the original task actions. A raising action skips that cleanup and leaves one frame on `ActiveRecord::Base.connected_to_stack`. A nested `db:` task also reuses the already-invoked push task, then pops the outer frame; observed action depths are `[1, 1, 0]` instead of `[1, 2, 1]`.

## Verification
- baseline model reproduces exception depth 1 and nested depths `[1, 1, 0]`
- fixed model ends at depth 0 after an exception and observes nested depths `[1, 2, 1]`
- repeated `enhance_db_tasks` calls remain idempotent
- existing Rake specs: 4 examples, 0 failures
- Rails 8.1.3.1 SQLite-focused suite plus Rake specs: 82 examples, 0 failures
- targeted RuboCop: no offenses

No tests or dependencies were changed. Developed with Codex assistance.